### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ FakeChrootFixture
 .. image:: https://coveralls.io/repos/yaybu/fakechroot/badge.png?branch=master
     :target: https://coveralls.io/r/yaybu/fakechroot
 
-.. image:: https://pypip.in/version/fakechroot/badge.png
+.. image:: https://img.shields.io/pypi/v/fakechroot.svg
     :target: https://pypi.python.org/pypi/fakechroot/
 
 This package provides a fixtures_ compatible fixture for building and


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fakechroot))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fakechroot`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.